### PR TITLE
Add minimal Jekyll blog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# kndl000
-Bitacora
+# Bitácora KNDL
+
+Este repositorio contiene un blog minimalista basado en [Jekyll](https://jekyllrb.com/) y Markdown preparado para GitHub Pages.
+
+## Uso
+
+1. Clona el repositorio y entra en la carpeta.
+2. Instala las dependencias ejecutando `bundle install` (requiere Ruby y Bundler).
+3. Inicia el servidor local con `bundle exec jekyll serve` para previsualizar los cambios.
+
+Al subir los cambios a GitHub, la página se generará automáticamente.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,12 @@
+# Minimal Jekyll configuration for GitHub Pages
+
+# Site settings
+title: "Bitácora KNDL"
+description: "Blog minimalista hecho con Jekyll y Markdown"
+author: "KNDL"
+
+# Build settings
+markdown: kramdown
+remote_theme: jekyll/minima
+plugins:
+ - jekyll-feed

--- a/_posts/2024-05-01-bienvenida.md
+++ b/_posts/2024-05-01-bienvenida.md
@@ -1,0 +1,6 @@
+---
+layout: post
+title: "Bienvenida"
+---
+
+Esta es la primera entrada de la bitácora. ¡Disfruta del contenido!

--- a/index.md
+++ b/index.md
@@ -1,0 +1,6 @@
+---
+layout: home
+title: "Bienvenido a la bitácora"
+---
+
+Este es un blog minimalista construido con [Jekyll](https://jekyllrb.com/) y Markdown. Aqui encontraras notas y registros.


### PR DESCRIPTION
## Summary
- set up Jekyll configuration and Gemfile
- add landing page and first post
- update README with usage notes

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68599883232083289033d0db1db99d96