### PR TITLE
Add autoplay background track

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,5 +11,6 @@
     <main>
       {{ content }}
     </main>
+    <iframe src="https://www.youtube.com/embed/QNS9RGB1GWg?autoplay=1&loop=1&playlist=QNS9RGB1GWg" style="display:none" allow="autoplay"></iframe>
   </body>
 </html>

--- a/musica.md
+++ b/musica.md
@@ -9,3 +9,4 @@ nav_order: 4
 
 
 - 🎧 [Death in June – but what ends when the symbols shatter](https://open.spotify.com/track/0eDgoWl60Zy57sInzzOi8a?si=442b8723724e477d)
+- 🎼 [Video de fondo](https://www.youtube.com/watch?v=QNS9RGB1GWg)


### PR DESCRIPTION
## Summary
- embed a hidden YouTube video in the default layout so the song plays automatically
- list the YouTube video on the music page

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found: jekyll`)*

------
https://chatgpt.com/codex/tasks/task_e_685ac7f0bc248328b4a46b46e41eedaa