### PR TITLE
∴ hermes: canonical melange link + poemas description

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ nav_order: 1
     <div id="home-nav-panel" class="home-nav__panel nube-de-palabras">
       <a href="{{ site.baseurl }}/poemas/">ↂ Poemas</a>
       <a href="{{ site.baseurl }}/visual/">◉ Visual</a>
-      <a href="{{ site.baseurl }}/melange">🜏 Melange </a>
+      <a href="{{ site.baseurl }}/melange/">🜏 Melange</a>
       <a href="{{ site.baseurl }}/codigo/">◊ Código</a>
       <a href="{{ site.baseurl }}/dispositivos/">◇ Devices</a>
     </div>

--- a/poemas/index.md
+++ b/poemas/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Poemas
+description: "Archivo de poemas — KNDL 000. Versos breves, simbólicos, fragmentarios. Voz que se deshace."
 ---
 
 {% assign sorted_poems = site.poems | sort: "date" | reverse %}


### PR DESCRIPTION
## ∴ Hermes · primer envío

Pequeño PR de higiene, sin cambios de comportamiento visibles (salvo que el link de Melange ya no pasa por un 301).

### Cambios

- **`index.md`** — nav de Melange: `/melange` → `/melange/` (URL canónica, evita redirect). También quité el espacio final del texto del link.
- **`poemas/index.md`** — añadí `description:` al front-matter. Las otras páginas del sitio lo tienen; esta no, así que su `<meta description>` y `og:description` salían vacíos.

### Lo que **no** toqué y por qué

- **`_data/fragmentos.yml`** — siete entradas tienen una forma YAML que parece rota (`lineas: <string>` seguido de `- linea:` huérfanos). Verifiqué con un parser estricto de Ruby: YAML los normaliza a arrays de un elemento y el loop de Liquid los itera sin problema. Riesgo de "arreglar" sin necesidad: cambiar la estructura podría alterar el orden o el slug que `lab-home.js` deriva del FNV-1a. Si quieres que los reformatee a la forma canónica `lineas:\n  - linea:` por consistencia visual, lo hago en un PR aparte.
- **`ESTRUCTURA.md`** — el doc lista secciones del nav (`Musica`, `Fragmentos`, `Generator`) que el commit `f985947` ya quitó. Es drift real, pero el fix es de ~10 líneas y no quiero mezclarlo con cambios en este PR.

### Verificación

- Front-matter parsea OK con `yaml.safe_load` (Python).
- Probé `https://kundala000.com/melange/` → `200`; `/melange` → `301`. Ahora el nav apunta al 200.
- No pude correr `bundle exec jekyll build` localmente (Ruby del sistema es 2.6, el lockfile pide 4.0.9). El CI de GitHub Actions lo validará.

### Firma

```
∴ Hermes
∴ ¿Cómo se firma uno que se firma por deducción? Con la marca del "por lo tanto".
```