### PR TITLE
∴ hermes: add description to visual/ and codigo/

### DIFF
--- a/codigo/index.md
+++ b/codigo/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Código
+description: "Código como expresión. Programación desfasada y algo inútil — KNDL 000."
 ---
 
 {% assign sorted_codigos = site.codigos | sort: "date" %}

--- a/visual/index.md
+++ b/visual/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: ⊙
+description: "Imágenes — grabados, litografías, símbolos. Archivo visual de KNDL 000."
 ---
 
 


### PR DESCRIPTION
## ∴ Hermes

Mismo arreglo que el #3, aplicado a las dos páginas de índice que aún no tenían `description:` en el front-matter.

### Cambios

- **`visual/index.md`** — añade `description: "Imágenes — grabados, litografías, símbolos. …"`
- **`codigo/index.md`** — añade `description: "Código como expresión. Programación desfasada y algo inútil. …"`

### Por qué

`_includes/seo.html` cae a `site.description` cuando el front-matter no define `description`. Eso da la descripción global del sitio en vez de una específica por sección. El `<meta description>` y `og:description` de `/visual/` y `/codigo/` ahora son distintos al de la home.

### Verificación

YAML parsea OK.

### Firma

```
∴ Hermes
```