### PR TITLE
∴ hermes: extract vestigios inline styles to CSS classes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1165,6 +1165,58 @@ main {
   color: #6d6560;
 }
 
+/* Vestigios — refactor de estilos inline de vestigios/index.md */
+.vestigio {
+  margin: 3rem 0;
+  padding: 1.5rem;
+  border-left: 1px solid #333;
+}
+
+.vestigio__title-link {
+  text-decoration: none;
+}
+
+.vestigio__title {
+  margin-top: 0;
+  color: #888;
+  font-size: 1rem;
+  font-weight: normal;
+}
+
+.vestigio__date {
+  color: #444;
+  font-size: 0.85rem;
+}
+
+.vestigio__image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 1rem 0;
+  opacity: 0.7;
+  border-radius: 4px;
+}
+
+.vestigio__body {
+  color: #666;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.vestigio__more {
+  color: #444;
+  font-size: 0.85rem;
+  text-decoration: none;
+  margin-top: 0.5rem;
+  display: inline-block;
+}
+
+.vestigio__sep {
+  border: none;
+  border-top: 1px solid #222;
+  margin: 2rem 0;
+}
+
 @media (max-width: 520px) {
   .poemas-index__row {
     gap: 0.5rem 0.75rem;

--- a/vestigios/index.md
+++ b/vestigios/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: ⚱ Vestigios ⚱
+description: "Lo que queda después. Objetos encontrados. Textos incompletos. Archivo de lo que persiste. — KNDL 000"
 ---
 
 > *Lo que queda después. Objetos encontrados. Textos incompletos. Archivo de lo que persiste.*
@@ -8,32 +9,29 @@ title: ⚱ Vestigios ⚱
 {% assign sorted_vestigios = site.vestigios | sort: "date" | reverse %}
 
 {% for vestigio in sorted_vestigios %}
-<div class="vestigio" style="margin: 3rem 0; padding: 1.5rem; border-left: 1px solid #333;">
-  <a href="{{ vestigio.url | relative_url }}" style="text-decoration: none;">
-    <h3 style="margin-top: 0; color: #888; font-size: 1rem; font-weight: normal;">
+<article class="vestigio">
+  <a class="vestigio__title-link" href="{{ vestigio.url | relative_url }}">
+    <h3 class="vestigio__title">
       {{ vestigio.title }}
       {% if vestigio.date %}
-        <span style="color: #444; font-size: 0.85rem;">({{ vestigio.date | date: "%Y-%m-%d" }})</span>
+        <span class="vestigio__date">({{ vestigio.date | date: "%Y-%m-%d" }})</span>
       {% endif %}
     </h3>
   </a>
-  
+
   {% if vestigio.image %}
-    <img src="{{ vestigio.image | relative_url }}" alt="{{ vestigio.title }}" style="max-width: 100%; height: auto; margin: 1rem 0; opacity: 0.7; border-radius: 4px;">
+    <img class="vestigio__image" src="{{ vestigio.image | relative_url }}" alt="{{ vestigio.title }}">
   {% endif %}
-  
-  <div style="color: #666; font-size: 0.9rem; line-height: 1.6;">
+
+  <div class="vestigio__body">
     {{ vestigio.content | strip_html | truncatewords: 30 }}
   </div>
-  
-  <a href="{{ vestigio.url | relative_url }}" style="color: #444; font-size: 0.85rem; text-decoration: none; margin-top: 0.5rem; display: inline-block;">
-    ↳ ver vestigio completo
-  </a>
-</div>
+
+  <a class="vestigio__more" href="{{ vestigio.url | relative_url }}">↳ ver vestigio completo</a>
+</article>
 
 {% if forloop.last == false %}
-<hr style="border: none; border-top: 1px solid #222; margin: 2rem 0;">
+<hr class="vestigio__sep">
 {% endif %}
 
 {% endfor %}
-


### PR DESCRIPTION
## ∴ Hermes

`vestigios/index.md` era el único `.md` de listado en el sitio construido casi entero con `style="…"` inline (8 declaraciones en 39 líneas). El resto del sitio usa clases BEM en `style.css`. Refactor de paridad.

### Cambios

- **`vestigios/index.md`** — 8 `style="…"` reemplazados por clases BEM (`.vestigio`, `.vestigio__title`, `.vestigio__date`, `.vestigio__image`, `.vestigio__body`, `.vestigio__more`, `.vestigio__title-link`, `.vestigio__sep`). `<div>` → `<article>` (cada vestigio es entrada autocontenida, no bloque genérico). Bonus: añadí `description:` al front-matter (faltaba, mismo patrón que #4).
- **`assets/css/style.css`** — bloque nuevo `.vestigio*` insertado tras `.poemas-index__series`. **Mismas propiedades** que los inline originales (color, padding, border, font-size, opacity, border-radius). Render byte-equivalente.

### Por qué

1. El sitio entero usa BEM en CSS. Vestigios era la excepción.
2. Los inline de `border-left: 1px solid #333` y `<hr>` con `border-top: 1px solid #222` sobre fondo negro son casi imperceptibles — están sin hacer nada visible. Este refactor no cambia el render real; abre la puerta a subirlos de contraste con un solo cambio de clase.
3. Mantener estilos en `.md` rompe el flujo: si mañana cambias la tipografía del sitio, los vestigios quedan atrás.

### Verificación

- 453 llaves `{` = 453 llaves `}` en `style.css` (chequeo de balance).
- 8 selectores `.vestigio*` matchean las 8 declaraciones inline originales.
- El bundle CSS de producción (Jekyll + GitHub Pages) regenerará el `_site/`.

### Lo que **no** toqué

- `style.css` líneas con otras definiciones (no metí aquí el ajuste de contraste — lo dejo para una decisión tuya, porque ahí ya es opinión estética, no paridad).
- Las imágenes de los vestigios (siguen apuntando a `/assets/media/images/object-000.png` etc.).
- El layout de la página (`<main>` envuelve igual).

### Firma

```
∴ Hermes
```
