### PR TITLE
∴ hermes: ci — bump actions to Node-24-capable + guard deploy

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect admin-relevant changes
         id: changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             admin:
@@ -35,13 +35,13 @@ jobs:
               - '.github/workflows/**'
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Cache node_modules
         id: cache-npm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Build with Jekyll
         run: bundle exec jekyll build
@@ -78,11 +78,12 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -91,4 +92,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## ∴ Hermes

Arregla los 2 errores + 1 warning que fallan el pipeline en cada PR. Dos issues no relacionados viviendo en el mismo archivo (`jekyll.yml`); los arreglo juntos porque separarlos serían 2 PRs por 1 línea cada uno.

### Issue 1 — Warning: Node.js 20 deprecation

`actions/checkout@v4`, `actions/setup-node@v4`, etc. corren sobre Node 20. GitHub forzará Node 24 el 2026-06-16 (mañana) y removerá Node 20 el 2026-09-16. Subir al major actual de cada action las mueve a Node 24 ya.

Bumps (versiones consultadas a la API de GitHub hoy, 2026-06-15):

| Action | Antes | Ahora |
|---|---|---|
| `actions/checkout` | v4 | v6.0.3 |
| `actions/cache` | v4 | v5.0.5 |
| `actions/setup-node` | v4 | v6.4.0 |
| `actions/configure-pages` | v4 | v6.0.0 |
| `actions/upload-pages-artifact` | v3 | v5.0.0 |
| `actions/deploy-pages` | v4 | v5.0.0 |
| `dorny/paths-filter` | v3 | v4.0.1 |

`ruby/setup-ruby` se queda en `@v1` (no está afectada por el deprecation, no requiere Node).

### Issue 2 — Error: `Branch refs/pull/N/merge is not allowed`

El job `deploy` no tenía condición. El `on: pull_request:` (sin filtro de branches) hacía que el deploy se disparara en **cada PR**. Pero el environment `github-pages` tiene reglas de protección que rechazan refs `pull/N/merge`. Resultado: cada PR fallaba deploy, aunque el build pasara.

**Fix:** guard `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` en el job `deploy`. Ahora:

- **PRs** → corre el `build` (validación barata, no toca producción).
- **Push a `main`** → corre `build` y luego `deploy` (la única vía que debe llegar a `github-pages`).

Esto es la convención de los starter workflows oficiales de GitHub Pages para Jekyll.

### Lo que **no** arreglé aquí

- **El environment `github-pages` sigue con reglas de protección activas.** Si quieres permitir deploy desde otras ramas (staging, por ejemplo), hay que ir a Settings → Environments → `github-pages` y añadir las refs. Eso no es código, es config de repo.
- **El LSP warning preexistente en `tina/config.ts:465`** (`default: "track"` en `personal_music.type`) — no relacionado, no introducido por mí. Si te molesta, lo arreglo en un PR aparte.

### Verificación

- YAML del workflow parsea sin errores (`yaml.safe_load`).
- Lint del patch pasó (`{lint: ok, output: ""}`).
- Las condiciones del job son visibles en el diff.

No puedo correr el CI desde aquí; el resultado se ve en el próximo run.

### Firma

```
∴ Hermes
∴ La diferencia entre "el CI falla" y "el CI hace lo que crees que hace" suele ser un `if:`.
```
