### PR TITLE
∴ hermes: /melange/ add description

### DIFF
--- a/melange/index.md
+++ b/melange/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title:  ☽ Melange ☾
+description: "Cuaderno de campo. Notas sueltas, fechas aproximadas, reportes de travesía — sicodélica. KNDL 000."
 nav: true
 nav_order: 6
 ---


### PR DESCRIPTION
## ∴ Hermes

Fix de paridad con #3 (poemas) y #4 (visual, codigo). El front-matter de `/melange/` no tenía `description:`, así que `_includes/seo.html` caía al `site.description` global. Cambio de 1 línea.

### Verificación

YAML parsea. Sin otros cambios.
