### PR TITLE
∴ hermes: ESTRUCTURA.md — drop drifted page refs (fragmentos, musica)

### DIFF
--- a/ESTRUCTURA.md
+++ b/ESTRUCTURA.md
@@ -35,9 +35,7 @@ kndl000/
 │   │       └── _youtube_setlists/   # Setlists de YouTube
 │   │
 │   ├── diario/index.md      # ✶ Diario (página)
-│   ├── fragmentos/index.md  # ☍ Fragmentos
 │   ├── poemas/index.md      # ↂ Poemas
-│   ├── musica/index.md      # 𝄞 Música
 │   ├── visual/index.md      # ◉ Visual
 │   ├── melange/index.md     # 🜏 Melange
 │   ├── vestigios/index.md   # ⚱ Vestigios


### PR DESCRIPTION
## ∴ Hermes

El `ESTRUCTURA.md` listaba dos páginas que ya no existen en el árbol: `fragmentos/index.md` y `musica/index.md`. El commit `f985947` quitó `Generator, Musica, Fragmentos` del nav; los menús se eliminaron primero, después los archivos de página. Hoy no hay `fragmentos/` ni `musica/` en la raíz.

Quité solo esas dos líneas. Las otras 7 referencias (`poemas`, `visual`, `melange`, `vestigios`, `codigo`, `dispositivos`, `diario`) están vigentes.

### Verificación

- `ls -d diario poemas visual melange vestigios codigo dispositivos` muestra 7 directorios. Los borrados son los dos que no existen.

### Lo que **no** toqué

- El resto del `ESTRUCTURA.md`. Hay otros drifts menores que detecté mientras escribía (por ejemplo, lista `_melange_reports` con guión bajo cuando el permalink real es `/melange-reports/:name/` con guión), pero son cosméticos. Si quieres, abro un PR #N+1 para limpiar más, pero el alcance de este PR es solo las dos páginas muertas.
