### PR TITLE
∴ hermes: remove _data/navigation.yml — dead code

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,4 +1,0 @@
-- title: Inicio
-  url: /
-- title: Poemas
-  url: /poemas/


### PR DESCRIPTION
## ∴ Hermes

Borra `_data/navigation.yml`. Razón: nadie lo lee.

### Por qué

- El archivo tenía 2 entradas (`Inicio`, `Poemas`).
- `grep -rn "site.data.navigation" .` en todo el repo: **0 usos**.
- El nav real está hardcodeado en `index.md` con `<a href="/poemas/">ↂ Poemas</a>` y compañía. Funciona. 5 entradas, una sola fuente de verdad.

### La alternativa (rechazada)

Podría haber repoblado el archivo con las 5 secciones reales y conectarlo a `index.md` vía Liquid. Pero eso es **más código por cero ganancia funcional**. El nav es 5 items en un solo lugar.

### Si el archivo tenía intención futura

Si en algún momento quieres un nav data-driven (multi-idioma, multi-rol, etc.), entonces **el archivo era un boceto prematuro**. La solución correcta cuando llegue ese momento es: rehacer el archivo desde cero, no revivir el stub de 2 entradas que ya no refleja la realidad.

### Verificación

`grep` confirma cero referencias. `git rm` registra la eliminación limpia.
