### PR TITLE
∴ hermes: 404.html — inline styles + onmouseover to BEM + CSS :hover

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,39 +8,23 @@ noindex: true
 
 > "Lo que buscas no está aquí. O tal vez nunca estuvo."
 
-<div style="text-align: center; margin: 3rem 0;">
-  <p style="color: #888; font-size: clamp(1rem, 3vw, 1.2rem); line-height: 1.8;">
+<div class="error-page">
+  <p class="error-page__message">
     La página que intentas encontrar se ha desvanecido.<br>
     Como un fragmento que se pierde en el tiempo.
   </p>
-</div>
 
-<div style="text-align: center; margin: 4rem 0;">
-  <a href="{{ '/' | relative_url }}" style="
-    color: #7ab6f5;
-    font-family: var(--font-serif);
-    font-size: clamp(1.2rem, 3vw, 1.5rem);
-    text-decoration: none;
-    padding: 0.5rem 1.5rem;
-    border: 1px solid #444;
-    border-radius: 4px;
-    display: inline-block;
-    transition: all 0.3s ease;
-  " onmouseover="this.style.borderColor='#7ab6f5'; this.style.color='#fff';" 
-     onmouseout="this.style.borderColor='#444'; this.style.color='#7ab6f5';">
-    ← Volver al inicio
-  </a>
-</div>
+  <a href="{{ '/' | relative_url }}" class="error-page__home">← Volver al inicio</a>
 
-<hr style="margin: 4rem 0; border-color: #333;">
+  <hr class="error-page__sep">
 
-<div style="text-align: center; color: #666; font-size: 0.9rem; font-style: italic;">
-  <p>O explora:</p>
-  <div class="nube-de-palabras" data-no-nube-motion style="padding: 1rem 0;">
-    <a href="{{ '/fragmentos/' | relative_url }}">☍ Fragmentos</a>
-    <a href="{{ '/poemas/' | relative_url }}">ↂ Poemas</a>
-    <a href="{{ '/visual/' | relative_url }}">◉ Visual</a>
-    <a href="{{ '/melange/' | relative_url }}">🜏 Melange</a>
+  <div class="error-page__explore">
+    <p>O explora:</p>
+    <div class="nube-de-palabras" data-no-nube-motion>
+      <a href="{{ '/fragmentos/' | relative_url }}">☍ Fragmentos</a>
+      <a href="{{ '/poemas/' | relative_url }}">ↂ Poemas</a>
+      <a href="{{ '/visual/' | relative_url }}">◉ Visual</a>
+      <a href="{{ '/melange/' | relative_url }}">🜏 Melange</a>
+    </div>
   </div>
 </div>
-

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1280,6 +1280,53 @@ main {
   margin: 2.5rem 0;
 }
 
+/* 404 — error page */
+.error-page {
+  text-align: center;
+  margin: 3rem 0;
+}
+
+.error-page__message {
+  color: #888;
+  font-size: clamp(1rem, 3vw, 1.2rem);
+  line-height: 1.8;
+  margin: 0 0 4rem;
+}
+
+.error-page__home {
+  display: inline-block;
+  color: #7ab6f5;
+  font-family: var(--font-serif);
+  font-size: clamp(1.2rem, 3vw, 1.5rem);
+  text-decoration: none;
+  padding: 0.5rem 1.5rem;
+  border: 1px solid #444;
+  border-radius: 4px;
+  transition: color 0.3s ease, border-color 0.3s ease;
+}
+
+.error-page__home:hover,
+.error-page__home:focus {
+  color: #fff;
+  border-color: #7ab6f5;
+}
+
+.error-page__sep {
+  border: none;
+  border-top: 1px solid #333;
+  margin: 4rem 0;
+}
+
+.error-page__explore {
+  color: #666;
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
+.error-page__explore p {
+  margin: 0 0 1rem;
+}
+
 .vestigio__image {
   display: block;
   max-width: 100%;


### PR DESCRIPTION
## ∴ Hermes

`404.html` tenía 4 `style="…"` inline y `onmouseover`/`onmouseout` handlers. Mismo refactor que #5 (vestigios) y #9 (codigo), pero más profundo: también quité JS inline.

### Cambios

- **`404.html`** — 4 inline `style="…"` + `onmouseover`/`onmouseout` reemplazados con BEM: `.error-page`, `__message`, `__home`, `__sep`, `__explore`. Estructura simplificada.
- **`assets/css/style.css`** — bloque `.error-page` añadido tras `.diario-entry__sep`. Incluye `:hover` y `:focus` para el botón home (a11y bonus: el focus de teclado dispara el mismo estilo que el hover del mouse).

### Por qué

- El sitio entero usa BEM en CSS, excepto `404.html` (y `vestigios/`/`codigo/`/`diario/` ya refactorizados).
- `onmouseover`/`onmouseout` en atributos HTML es JS inline pre-CSS3. Hoy es ruido. CSS `:hover` hace lo mismo, **y** `:focus` lo extiende al teclado.
- Eliminar el JS inline reduce el peso del HTML y mejora la accesibilidad (los focus styles son importantes para usuarios de teclado).

### Verificación

- 475 llaves `{` = 475 llaves `}` en `style.css` (balance).
- Sin inline `style=` en el HTML resultante.
- Sin atributos `onmouseover`/`onmouseout`.

### Nota sobre el rebase

Esta PR fue rebaseada sobre `origin/main` después del merge de #10. Por eso el force-push. Historia lineal, no hay merge commits.

### Firma

```
∴ Hermes
∴ Lo que se puede decir con CSS no necesita JS. Lo que se puede decir con foco no necesita mouse.
```
