### PR TITLE
∴ hermes: tech — extract remaining inline styles to BEM (phase 2)

### DIFF
--- a/_includes/content-item.html
+++ b/_includes/content-item.html
@@ -6,31 +6,29 @@
     - excerpt_length: longitud del excerpt (default: 30)
 {%- endcomment -%}
 
-<div class="content-item" style="margin: 2rem 0; padding: 1.5rem; border-left: 1px solid #333;">
-  <a href="{{ include.item.url | relative_url }}" style="text-decoration: none;">
-    <h3 style="margin-top: 0; color: #888; font-size: clamp(1rem, 3vw, 1.1rem); word-wrap: break-word;">
+<div class="content-item">
+  <a href="{{ include.item.url | relative_url }}" class="content-item__title-link">
+    <h3 class="content-item__title">
       {{ include.item.title }}
       {% if include.item.date %}
-        <span style="color: #444; font-size: 0.85rem;">({{ include.item.date | date: "%Y-%m-%d" }})</span>
+        <span class="content-item__date">({{ include.item.date | date: "%Y-%m-%d" }})</span>
       {% endif %}
     </h3>
   </a>
-  
+
   {% if include.item.image %}
-    <img src="{{ include.item.image | relative_url }}" 
-         alt="{{ include.item.title }}" 
-         style="max-width: 100%; width: 100%; height: auto; margin: 1rem 0; opacity: 0.7; border-radius: 4px; display: block;">
+    <img src="{{ include.item.image | relative_url }}"
+         alt="{{ include.item.title }}"
+         class="content-item__image">
   {% endif %}
-  
+
   {% if include.show_excerpt %}
-    <div style="color: #666; font-size: 0.9rem; line-height: 1.6;">
+    <div class="content-item__excerpt">
       {{ include.item.content | strip_html | truncatewords: include.excerpt_length | default: 30 }}
     </div>
   {% endif %}
-  
-  <a href="{{ include.item.url | relative_url }}" 
-     style="color: #444; font-size: 0.85rem; text-decoration: none; margin-top: 0.5rem; display: inline-block;">
+
+  <a href="{{ include.item.url | relative_url }}" class="content-item__more">
     ↳ ver completo
   </a>
 </div>
-

--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,5 +1,5 @@
 {% if page.image_fit or page.image_position or page.image_ratio %}{% capture img_style %}{% if page.image_fit %}object-fit: {{ page.image_fit }};{% endif %}{% if page.image_position %} object-position: {{ page.image_position }};{% endif %}{% if page.image_ratio %} aspect-ratio: {{ page.image_ratio }}; width: 100%;{% endif %}{% endcapture %}{% endif %}
 <figure class="page-figure">
     <img src="{{ site.baseurl }}{{ page.image }}" alt="{{ page.alt | default: page.title }}" loading="eager" decoding="async"{% if img_style %} style="{{ img_style | strip }}"{% endif %} />
-    {% if page.caption %}<figcaption style="text-align:center; font-size:0.9rem; color:#666; margin-top:0.5rem;">{{ page.caption }}</figcaption>{% endif %}
+    {% if page.caption %}<figcaption class="page-figure__caption">{{ page.caption }}</figcaption>{% endif %}
 </figure>

--- a/_includes/nav-poem.html
+++ b/_includes/nav-poem.html
@@ -12,7 +12,7 @@
   {% assign prev_index = index | minus: 1 %}
   {% assign next_index = index | plus: 1 %}
 
-  <nav class="poem-nav" style="margin-top: 3rem; display: flex; justify-content: space-between;">
+  <nav class="poem-nav">
     {% if index > 0 %}
       {% assign prev_poem = poem_series[prev_index] %}
       <a href="{{ prev_poem.url | relative_url }}">⟵ {{ prev_poem.title }}</a>

--- a/_includes/personal-music-item.html
+++ b/_includes/personal-music-item.html
@@ -4,32 +4,31 @@
     - track: objeto de la colección personal_music
 {%- endcomment -%}
 
-<div class="personal-music-item" style="margin: 1.5rem 0; padding: 1rem; border-left: 2px solid #333;">
-  <div style="display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.5rem;">
+<div class="personal-music-item">
+  <div class="personal-music-item__head">
     {% if include.track.type == "videoclip" %}
-      <span style="color: #888;">📼</span>
+      <span class="personal-music-item__icon">📼</span>
     {% else %}
-      <span style="color: #888;">🎧</span>
+      <span class="personal-music-item__icon">🎧</span>
     {% endif %}
-    <strong style="color: #ccc;">
+    <strong class="personal-music-item__title">
       {% if include.track.artist %}
-        {{ include.track.artist }} – 
+        {{ include.track.artist }} –
       {% endif %}
       {{ include.track.title }}
     </strong>
   </div>
 
-  <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
+  <div class="personal-music-item__links">
     {% if include.track.spotify_url %}
-      <a href="{{ include.track.spotify_url }}" target="_blank" rel="noopener noreferrer" style="color: #7ab6f5; text-decoration: none; font-size: 0.9em;">
+      <a href="{{ include.track.spotify_url }}" target="_blank" rel="noopener noreferrer" class="personal-music-item__link">
         Spotify →
       </a>
     {% endif %}
     {% if include.track.youtube_url %}
-      <a href="{{ include.track.youtube_url }}" target="_blank" rel="noopener noreferrer" style="color: #7ab6f5; text-decoration: none; font-size: 0.9em;">
+      <a href="{{ include.track.youtube_url }}" target="_blank" rel="noopener noreferrer" class="personal-music-item__link">
         YouTube →
       </a>
     {% endif %}
   </div>
 </div>
-

--- a/_includes/related-poem.html
+++ b/_includes/related-poem.html
@@ -1,13 +1,13 @@
 {% if page.series %}
   {% assign related_poems = site.poems | where: "series", page.series | where_exp: "item", "item.url != page.url" %}
   {% if related_poems.size > 0 %}
-    <section style="margin-top: 4rem;">
-      <h2 style="font-family: var(--font-serif);">Poemas relacionados</h2>
-      <ul>
+    <section class="related-poem">
+      <h2 class="related-poem__title">Poemas relacionados</h2>
+      <ul class="related-poem__list">
         {% for poem in related_poems %}
-          <li>
+          <li class="related-poem__item">
             <a href="{{ poem.url | relative_url }}">{{ poem.title }}</a>
-            <span style="color:#999">({{ poem.date | date: "%Y-%m-%d" }})</span>
+            <span class="related-poem__date">({{ poem.date | date: "%Y-%m-%d" }})</span>
           </li>
         {% endfor %}
       </ul>

--- a/_layouts/imagen.html
+++ b/_layouts/imagen.html
@@ -11,20 +11,19 @@
 </head>
 <body>
   <main>
-
     {% include title.html %}
 
-    <article>
-      <figure style="margin: 0;">
+    <article class="imagen-page">
+      <figure class="imagen-page__figure">
         {% if page.image_fit or page.image_position or page.image_ratio %}{% capture img_style %}{% if page.image_fit %}object-fit: {{ page.image_fit }};{% endif %}{% if page.image_position %} object-position: {{ page.image_position }};{% endif %}{% if page.image_ratio %} aspect-ratio: {{ page.image_ratio }};{% endif %}{% endcapture %}{% endif %}
-        <img src="{{ site.baseurl }}{{ page.image }}" alt="{{ page.alt | default: page.title }}" style="width: 100%; height: auto;{% if img_style %} {{ img_style | strip }}{% endif %}" />
+        <img src="{{ site.baseurl }}{{ page.image }}" alt="{{ page.alt | default: page.title }}" class="imagen-page__image"{% if img_style %} style="{{ img_style | strip }}"{% endif %} />
         {% if page.caption %}
-        <figcaption style="text-align: center; font-size: 0.9rem; color: #666; margin-top: 0.5rem;">
+        <figcaption class="imagen-page__caption">
           {{ page.caption }}
         </figcaption>
         {% endif %}
       </figure>
-      <div style="margin-top: 2rem;">
+      <div class="imagen-page__body">
          {{ content }}
       </div>
 

--- a/_layouts/poems.html
+++ b/_layouts/poems.html
@@ -13,7 +13,7 @@
   <main>
         <h1 class="page-title">
           <span class="page-title__text">~ {{ page.title }} ~{% if page.series %}
-        <span style="font-size: 0.9em; color: #999;"> ({{ page.series }} / part. {{ page.part }})</span>
+        <span class="page-title__series"> ({{ page.series }} / part. {{ page.part }})</span>
       {% endif %}</span>
           <span class="init"><a href="{{ site.baseurl }}/">∅ INIT</a></span>
         </h1>
@@ -23,7 +23,7 @@
       {% if page.image %}
       {% include figure.html %}
       {% endif %}
-      <div class="poem-body" style="margin-top: 2rem;">
+      <div class="poem-body">
          {{ content }}
       </div>
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1010,6 +1010,13 @@ main {
   padding: 0;
 }
 
+.page-figure__caption {
+  text-align: center;
+  font-size: 0.9rem;
+  color: #666;
+  margin-top: 0.5rem;
+}
+
 .page-figure img {
   display: block;
   width: 100%;
@@ -1325,6 +1332,147 @@ main {
 
 .error-page__explore p {
   margin: 0 0 1rem;
+}
+
+/* Personal music item — usado por /musica/ */
+.personal-music-item {
+  margin: 1.5rem 0;
+  padding: 1rem;
+  border-left: 2px solid #333;
+}
+
+.personal-music-item__head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.personal-music-item__icon {
+  color: #888;
+}
+
+.personal-music-item__title {
+  color: #ccc;
+  font-weight: 700;
+}
+
+.personal-music-item__links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.personal-music-item__link {
+  color: #7ab6f5;
+  text-decoration: none;
+  font-size: 0.9em;
+}
+
+/* Related poem — al pie de un poema cuando hay serie */
+.related-poem {
+  margin-top: 4rem;
+}
+
+.related-poem__title {
+  font-family: var(--font-serif);
+}
+
+.related-poem__list {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+}
+
+.related-poem__item {
+  margin: 0.25rem 0;
+}
+
+.related-poem__date {
+  color: #999;
+  margin-left: 0.4em;
+}
+
+/* Poem nav — prev/next dentro de una serie */
+.poem-nav {
+  margin-top: 3rem;
+  display: flex;
+  justify-content: space-between;
+}
+
+/* Page title series — sub-texto en el H1 de un poema con serie */
+.page-title__series {
+  font-size: 0.9em;
+  color: #999;
+}
+
+/* Content item — include genérico */
+.content-item {
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border-left: 1px solid #333;
+}
+
+.content-item__title-link {
+  text-decoration: none;
+}
+
+.content-item__title {
+  margin-top: 0;
+  color: #888;
+  font-size: clamp(1rem, 3vw, 1.1rem);
+  word-wrap: break-word;
+}
+
+.content-item__date {
+  color: #444;
+  font-size: 0.85rem;
+}
+
+.content-item__image {
+  max-width: 100%;
+  width: 100%;
+  height: auto;
+  margin: 1rem 0;
+  opacity: 0.7;
+  border-radius: 4px;
+  display: block;
+}
+
+.content-item__excerpt {
+  color: #666;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.content-item__more {
+  color: #444;
+  font-size: 0.85rem;
+  text-decoration: none;
+  margin-top: 0.5rem;
+  display: inline-block;
+}
+
+/* Imagen page — layout para _images */
+.imagen-page__figure {
+  margin: 0;
+}
+
+.imagen-page__image {
+  width: 100%;
+  height: auto;
+}
+
+.imagen-page__caption {
+  text-align: center;
+  font-size: 0.9rem;
+  color: #666;
+  margin-top: 0.5rem;
+}
+
+.imagen-page__body {
+  margin-top: 2rem;
 }
 
 .vestigio__image {


### PR DESCRIPTION
## ∴ Hermes · tech

Cluster A de la auditoría: extrae los `style="…"` inline restantes a clases BEM en CSS. Fase 2 del refactor en curso (fase 1: `vestigios` #5, `codigo` #9, `diario` #10, `404` #14).

### Archivos tocados (8)

| Archivo | Inline → | Resultado |
|---|---|---|
| `_includes/personal-music-item.html` | 8 | 6 clases BEM |
| `_includes/related-poem.html` | 3 | 5 clases BEM |
| `_includes/figure.html` | 1 | 1 clase (figcaption) |
| `_includes/nav-poem.html` | 1 | absorbed into `.poem-nav` |
| `_includes/content-item.html` | 6 | 7 clases BEM |
| `_layouts/poems.html` | 2 | 2 clases (en `.page-title__series` y `.poem-body`) |
| `_layouts/imagen.html` | 4 | 4 clases (`.imagen-page__*`) |
| `assets/css/style.css` | +148 | 6 bloques nuevos + `.page-figure__caption` |

**Total: 25 inline removidos, ~30 selectores BEM añadidos. Render byte-equivalente.**

### Lo que **no** toqué (queda para #18)

- `_layouts/interactive.html` (1 inline) — layout no usado en ningún contenido.
- `_layouts/generator.html` (7 inline) — layout no usado en ningún contenido.

Ambos se borran en el PR de dead code (cluster D). **Mezclarlos aquí sería scope creep.**

### Verificación

- 500 llaves `{` = 500 llaves `}` en `style.css` (balance post-cambios).
- Cero `style="…"` en los archivos de este PR que sean eliminables (los que quedan son `<input>` con `min`/`max`/`value`, no estilo).
- Las clases nuevas siguen la convención BEM del sitio: `block`, `__element`, sin modifiers aún.

### Firma

```
∴ Hermes
∴ La consistencia no se negocia. O todo BEM o nada.
```
