### PR TITLE
∴ hermes: tech — add 'dispositivos' to Tina schema

### DIFF
--- a/tina/config.ts
+++ b/tina/config.ts
@@ -86,6 +86,58 @@ export default defineConfig({
         ],
       },
       {
+        name: "dispositivos",
+        label: "◇ Dispositivos",
+        path: "content/collections/_dispositivos",
+        format: "md",
+        fields: [
+          {
+            type: "string" as const,
+            name: "layout",
+            label: "Layout",
+            options: ["dispositivo", "default"],
+          },
+          ...createCommonFields(["title", "image", "date", "body"]),
+          {
+            type: "string" as const,
+            name: "kind",
+            label: "Tipo",
+            description: "Categoría del dispositivo (vst, app, tool).",
+            options: ["vst", "app", "tool"],
+          },
+          {
+            type: "string" as const,
+            name: "tech",
+            label: "Tech",
+            description: "Stack técnico principal (TypeScript, C++, JUCE, etc.).",
+          },
+          {
+            type: "string" as const,
+            name: "demo_url",
+            label: "Demo URL",
+            description: "Enlace a demo, web del proyecto, o video.",
+          },
+          {
+            type: "string" as const,
+            name: "repo",
+            label: "Repo URL",
+            description: "URL del repositorio (GitHub, GitLab, etc.).",
+          },
+          {
+            type: "string" as const,
+            name: "formats",
+            label: "Formatos",
+            description: "Formatos soportados (VST3, AU, LV2, standalone, ...).",
+          },
+          {
+            type: "string" as const,
+            name: "platform",
+            label: "Plataforma",
+            description: "Sistemas operativos soportados (macOS · Windows · Linux).",
+          },
+        ],
+      },
+      {
         name: "codigos",
         label: "◊ Código",
         path: "content/collections/_codigos",


### PR DESCRIPTION
## ∴ Hermes · tech

Cluster B de la auditoría. La colección Jekyll `dispositivos` existía en `_config.yml` con un archivo de ejemplo en `content/collections/_dispositivos/ejemplo.md`, pero no estaba en el schema de Tina. Eso significaba que Tina no podía editarla desde el admin.

### Cambios

- **`tina/config.ts`** — colección `dispositivos` añadida al schema con los campos que el archivo de ejemplo ya usa:
  - `layout` (dispositivo, default)
  - `title`, `image`, `date`, `body` (vía `createCommonFields`)
  - `kind` (enum: vst, app, tool)
  - `tech`, `demo_url`, `repo`, `formats`, `platform` (strings con description)

### Lo que **no** regenera

`tina/tina-lock.json` no se actualiza en este commit. Tina regenera ese archivo en el próximo `npm run dev` / build del admin. **El schema es la fuente de verdad; el lock es un snapshot derivado.** Cuando el admin de Tina se reconstruya, el lock añadirá la entrada `DispositivosMutation` con los 9 campos.

### Lo que **no** arreglé

- El LSP warning preexistente en `tina/config.ts:501:13` (`default: "track"` en `personal_music.type`) — bug anterior a este PR, no introducido por mí. Lo arreglo si quieres en un PR aparte.
- `_data/fragmentos.yml` legacy se aborda en el cluster D (PR #18).

### Verificación

- Schema parsea. 108 llaves balanceadas.
- `name: "dispositivos"` y `path: "content/collections/_dispositivos"` confirmados con regex.
- El archivo `ejemplo.md` cumple el nuevo schema (todos los campos que tiene están declarados; el resto puede añadirse por Tina).

### Firma

```
∴ Hermes
```
