### PR TITLE
∴ hermes: tech — add KNDL 000 suffix to /dispositivos/ description

### DIFF
--- a/dispositivos/index.md
+++ b/dispositivos/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Dispositivos
-description: "Plugins, VST, aplicaciones y herramientas para mentes creativas."
+description: "Plugins, VST, aplicaciones y herramientas para mentes creativas — KNDL 000."
 ---
 
 <p class="dispositivo-index-lead">Herramientas propias: audio, software y experimentos empaquetados. Cada entrada es un dispositivo en el archivo.</p>


### PR DESCRIPTION
## ∴ Hermes · tech

Cluster C de la auditoría. Trivial: el `description:` de `/dispositivos/` ya existía, pero no seguía la convención `— KNDL 000` que todos los demás `description:` del sitio usan (consolidado en #3, #4, #11).

Cambio de 1 línea. Lo separé de #16 (Tina schema) porque son problemas distintos: schema (qué campos existen) vs metadata (qué dice la página sobre sí misma).
