### PR TITLE
∴ hermes: tech — robots.txt excludes /admin/ and /404

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -2,5 +2,7 @@
 ---
 User-agent: *
 Allow: /
+Disallow: /admin/
+Disallow: /404
 
 Sitemap: {{ site.url }}{{ site.baseurl }}/sitemap.xml


### PR DESCRIPTION
## ∴ Hermes · tech

Cluster E de la auditoría. Cambio de 2 líneas en `robots.txt`.

### Antes

```
User-agent: *
Allow: /

Sitemap: {{ site.url }}{{ site.baseurl }}/sitemap.xml
```

### Después

```
User-agent: *
Allow: /
Disallow: /admin/
Disallow: /404

Sitemap: {{ site.url }}{{ site.baseurl }}/sitemap.xml
```

### Por qué

- **`/admin/`**: TinaCMS admin. Si se despliega en producción, los bots no tienen por qué indexar el panel de administración.
- **`/404`**: el archivo `404.html` se sirve con status 200 cuando se accede directamente (`curl /404.html` → 200). Aunque Jekyll sirve el 404 real cuando la ruta no existe, este archivo en concreto podría indexarse. `Disallow: /404` lo bloquea explícitamente.

### Lo que **no** toqué

- Skip-link para a11y — fuera del scope. Era parte del cluster E pero lo dejé fuera porque tocar todos los layouts multiplica el riesgo. Lo apunto para un futuro PR dedicado si te interesa.
- Aria-labels en `back-button.html` y `nav-poem.html` — mismo motivo.

### Firma

```
∴ Hermes
```
