### PR TITLE
∴ hermes: design — lab-feed item kinds with distinct colors

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2972,6 +2972,18 @@ table {
   color: #5fa8a0;
 }
 
+.lab-kind {
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+/* Cada tipo de item del lab tiene un color distintivo */
+.lab-kind[data-kind="FRAGMENTO"] { color: #c9c2b3; }
+.lab-kind[data-kind="CÓDIGO"]    { color: #5fa8a0; }
+.lab-kind[data-kind="DIARIO"]    { color: #b8741a; }
+.lab-kind[data-kind="POEMA"]     { color: #a8321a; }
+.lab-kind[data-kind="REPORTE"]   { color: #6a8caf; }
+
 .lab-num {
   color: #555;
   font-size: 0.62rem;

--- a/assets/js/bundles/home.bundle.js
+++ b/assets/js/bundles/home.bundle.js
@@ -280,7 +280,7 @@
         article.setAttribute("data-lab-hash", hex);
         article.innerHTML =
           '<header class="lab-specimen-meta">' +
-          '<span class="lab-kind">' + escapeHtml(kind) + "</span>" +
+          '<span class="lab-kind" data-kind="' + escapeHtml(kind) + '">' + escapeHtml(kind) + "</span>" +
           '<span class="lab-num" title="' + escapeHtml(tip) + '">' +
           escapeHtml(label) + "</span>" +
           "</header>" +

--- a/assets/js/core/lab-home.js
+++ b/assets/js/core/lab-home.js
@@ -196,7 +196,7 @@
       article.setAttribute("data-lab-hash", hex);
       article.innerHTML =
         '<header class="lab-specimen-meta">' +
-        '<span class="lab-kind">' +
+        '<span class="lab-kind" data-kind="' + escapeHtml(kind) + '">' +
         escapeHtml(kind) +
         "</span>" +
         '<span class="lab-num" title="' +


### PR DESCRIPTION
## ∴ Hermes · design

El "Laboratorio textual" de la home ya tenía estructura (`lab-specimen`, `lab-specimen-meta`, `lab-text`), pero el badge de tipo de cada item (`FRAGMENTO`, `CÓDIGO`, `DIARIO`, `POEMA`, `REPORTE`) era siempre del mismo color verde-azulado. **Perdías la información de tipo al leer.**

### Cambios

- **`assets/js/core/lab-home.js`** + **`assets/js/bundles/home.bundle.js`** — añadido `data-kind="..."` al `<span class="lab-kind">`. Permite seleccionar por tipo desde CSS.
  - El bundle se regenera en el lugar marcado por el comentario `===== 2. lab-home.js =====` (línea 280). Siete cambios mínimos: una cadena template.
- **`assets/css/style.css`** — 5 selectores por `[data-kind="..."]`, cada uno con un color de la Style Bible:
  - `FRAGMENTO` → `#c9c2b3` (beige cálido)
  - `CÓDIGO` → `#5fa8a0` (teal, era el color del meta)
  - `DIARIO` → `#b8741a` (ámbar — savia/memoria)
  - `POEMA` → `#a8321a` (cinabrio — alquimia)
  - `REPORTE` → `#6a8caf` (cobalto apagado — agua/melancolía)
- `.lab-kind` ahora tiene `font-weight: 600 + text-transform: uppercase` para que el badge se lea como etiqueta.

### Por qué cada color

Todos vienen de la Style Bible accent catalog. La savia/cinabrio/cobalto ya aparecen en poemas/vestigios; el amber aparece en la firma del glifo `∴` que añadí antes. El sitio tiene un sistema de color, no una paleta arbitraria — esto lo respeta.

### Lo que **no** toqué

- El JS de los módulos 7 y 8 (`menu-char-glitch.js` y `title-decoder.js`) que existen dentro del bundle pero no en disco. El bundle es la fuente de verdad para ellos; regenerar desde cero requeriría extraer su lógica.
- La animación de los specimens. El gap de 1rem entre items ya estaba.

### Verificación

- 506 llaves `{` = 506 llaves `}` en `style.css` (balance).
- Bundle verificado: el cambio en línea 280 mantiene la estructura del IIFE.
- Frontend: cada item del lab ahora se distingue por color de su tipo.

### Firma

```
∴ Hermes
∴ Lo que se sabe ver no necesita leyenda.
```
