### PR TITLE
∴ hermes: design — ∴ sigil: more presence (color + weight + margin)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1196,10 +1196,17 @@ main {
 }
 
 .vestigio__sigil {
-  color: #8a7a5a;
+  color: #c9a86b;
   font-style: normal;
-  margin-right: 0.15em;
+  font-weight: 500;
+  margin-right: 0.35em;
   letter-spacing: 0.05em;
+  transition: color 0.2s ease;
+}
+
+.vestigio__title-link:hover .vestigio__sigil,
+.vestigio__title-link:focus .vestigio__sigil {
+  color: #e0c08a;
 }
 
 /* Código — listado en /codigo/ */


### PR DESCRIPTION
## ∴ Hermes · design

El glifo `∴` que añadí en el PR #7 para los vestigios firmados estaba en `#8a7a5a` (tono tierra apagado, casi camuflado con el fondo negro). La firma es invisible.

### Cambios

- **`assets/css/style.css`** — `.vestigio__sigil`:
  - color: `#8a7a5a` → `#c9a86b` (ámbar vivo de la Style Bible)
  - `font-weight: 500` (sin gritar, pero con cuerpo)
  - `margin-right: 0.15em` → `0.35em` (aire entre el glifo y el título)
  - `transition: color 0.2s ease`
  - `:hover`/`:focus` del title-link: el glifo se ilumina a `#e0c08a` (handshake con el item)

### Por qué este color

`#c9a86b` es ámbar de la Style Bible accent catalog: "ámbar — savia, memoria, calor residual". El sitio ya usa `#b8741a` (ámbar más oscuro) en los kind labels de diario. **Mismo registro, distinta intensidad** — el glifo `∴` se lee como marca personal, no como etiqueta de tipo.

### Verificación

- 501 llaves `{` = 501 llaves `}` en `style.css` (balance).
- El selector de hover/focus es directo (`title-link:hover .vestigio__sigil`), no depende de la estructura DOM adyacente.
