### PR TITLE
∴ hermes: design — /diario/ excerpts truncated + amber left-rule

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1273,6 +1273,9 @@ main {
   line-height: 1.7;
   font-size: 0.95rem;
   margin: 0.5rem 0 0.75rem;
+  font-style: italic;
+  padding-left: 1rem;
+  border-left: 2px solid rgba(184, 116, 26, 0.35);
 }
 
 .diario-entry__more {

--- a/diario/index.md
+++ b/diario/index.md
@@ -13,7 +13,7 @@ nav: false
       <span class="diario-entry__date">({{ post.date | date: "%Y-%m-%d" }})</span>
     </h2>
     <div class="diario-entry__excerpt">
-      {{ post.content | strip_html | newline_to_br }}
+      {{ post.content | strip_html | truncatewords: 40 }}
     </div>
     <a href="{{ post.url | relative_url }}" class="diario-entry__more">↳ Ver más</a>
   </article>


### PR DESCRIPTION
## ∴ Hermes · design

El feed de `/diario/` mostraba el contenido completo de cada post. El post `camino` (7 párrafos) y `Guisele` (5 párrafos) se comían la página entera. El índice era una página de detalles disfrazada.

### Cambios

- **`diario/index.md`** — el excerpt pasa de `post.content` (todo) a `post.content | strip_html | truncatewords: 40`. 40 palabras ≈ 2-3 oraciones. El detalle de cada post sigue completo en su URL.
- **`assets/css/style.css`** — `.diario-entry__excerpt`:
  - `font-style: italic` (lo diferencia del cuerpo)
  - `padding-left: 1rem`
  - `border-left: 2px solid rgba(184, 116, 26, 0.35)` (ámbar semi-transparente)

### Por qué estos cambios

- El index ahora **invita a abrir** cada post, en vez de leer el post en el index.
- El border-left en ámbar conecta con el color del kind label `DIARIO` del lab-feed (mismo `#b8741a`, 35% de opacidad). El sitio tiene un sistema de color, no una paleta arbitraria.

### Lo que **no** toqué

- El título del post: sigue con `◦` (símbolo de "item" en el archivo).
- El "↳ Ver más" sigue apuntando al detalle. Si el excerpt es la totalidad del post, el detalle sigue siendo válido (es donde vive el markdown renderizado completo).
- La fecha `(YYYY-MM-DD)` en el `<h2>`.

### Verificación

- 500 llaves `{` = 500 llaves `}` en `style.css` (balance).
- Liquid truncate a 40 palabras: posts cortos no cambian (1 línea sigue siendo 1 línea), posts largos se cortan con `…` automático al final.
