### PR TITLE
∴ hermes: design — codigo binary sigil framed as an identity badge

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1216,10 +1216,18 @@ main {
 }
 
 .codigo-list__binary {
+  display: inline-block;
   color: #5fa8a0;
   font-family: var(--font-mono);
-  font-size: 0.85em;
-  margin-right: 0.5em;
+  font-size: 0.78em;
+  letter-spacing: 0.08em;
+  padding: 0.1em 0.55em 0.15em;
+  margin-right: 0.7em;
+  border: 1px solid rgba(95, 168, 160, 0.4);
+  border-radius: 3px;
+  background: rgba(95, 168, 160, 0.04);
+  font-weight: 500;
+  vertical-align: 0.05em;
 }
 
 .codigo-list__title {


### PR DESCRIPTION
## ∴ Hermes · design

La signature binaria `#00000000` en `/codigo/` era solo un span de color teal flotando al lado del título. **Sin marco, sin contenedor.** Pierde identidad visual.

### Cambios

- **`assets/css/style.css`** — `.codigo-list__binary`:
  - `display: inline-block` (necesario para el padding)
  - `padding: 0.1em 0.55em 0.15em` (aire interno)
  - `border: 1px solid rgba(95, 168, 160, 0.4)` (marco sutil)
  - `border-radius: 3px` (esquinas mínimamente redondeadas)
  - `background: rgba(95, 168, 160, 0.04)` (fondo sutil teal)
  - `font-weight: 500` (cuerpo)
  - `letter-spacing: 0.08em` (espaciado binario)
  - `vertical-align: 0.05em` (alinea con la baseline del título)

### Por qué

- El sitio tiene una lógica de "marcadores de identidad": el glifo `∴` en vestigios (PR #22), los kind labels de colores en el lab-feed (PR #21). El binary en código es **el tercer marcador de identidad** del sitio, y merece el mismo trato.
- Sigue siendo sobrio: el badge es mínimo (1px border, fondo casi invisible). No compite con el título, lo precede.
- El teal `#5fa8a0` es el color del kind `CÓDIGO` en el lab-feed. Consistencia.

### Verificación

- 500 llaves `{` = 500 llaves `}` en `style.css` (balance).
- Render: cada item de `/codigo/` se ve como `#00000000 [Título]`, con el binario enmarcado. Limpio.
