### PR TITLE
∴ hermes: design — lab-feed mono-acento (override the 5-color merge)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2982,20 +2982,13 @@ table {
   font-family: var(--font-ui-mono);
   font-size: 0.7rem;
   letter-spacing: 0.08em;
-  color: #5fa8a0;
+  color: #a8a35c;
 }
 
 .lab-kind {
   font-weight: 600;
   text-transform: uppercase;
 }
-
-/* Cada tipo de item del lab tiene un color distintivo */
-.lab-kind[data-kind="FRAGMENTO"] { color: #c9c2b3; }
-.lab-kind[data-kind="CÓDIGO"]    { color: #5fa8a0; }
-.lab-kind[data-kind="DIARIO"]    { color: #b8741a; }
-.lab-kind[data-kind="POEMA"]     { color: #a8321a; }
-.lab-kind[data-kind="REPORTE"]   { color: #6a8caf; }
 
 .lab-num {
   color: #555;


### PR DESCRIPTION
∴ Hermes
PR #21 was merged at 18:27:58Z, but it took the original b2b7cb2 commit (the 5-color system), not the 4083455 commit I had force-pushed to design/lab-feed-hierarchy (the mono-acento fix). The site deployed the 5 colors.

This commit reapplies the mono-acento CSS on top of main: removes the 5 [data-kind='...'] selectors, restores the single color #a8a35c (verde CRT apagado).

The data-kind attribute stays in the HTML (zero cost, keeps the option to re-tematize by kind later without re-bundling).

This is a fix-up, not a new design. Same intent as PR #26 (which was closed as duplicate of this same change on the design/lab-feed-hierarchy branch).