### PR TITLE
∴ hermes: tech — cache-bust the main stylesheet on each deploy

### DIFF
--- a/_includes/head-css.html
+++ b/_includes/head-css.html
@@ -1,0 +1,7 @@
+{%- comment -%}
+  Cache-buster for the main stylesheet.
+  Fastly (GH Pages CDN) caches style.css for 4h. Appending a build-time
+  version token makes the URL unique per deploy, bypassing the cache.
+{%- endcomment -%}
+{%- assign css_ts = site.time | date: '%s%N' -%}
+<link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: css_ts | relative_url }}">

--- a/_layouts/codigo.html
+++ b/_layouts/codigo.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }} – {{ site.title }}{% endif %}</title>
     {% include seo.html %}
-    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+    {% include head-css.html %}
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Lato:ital,wght@0,300;0,400;0,700;1,400&family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet">
     {% include analytics.html %}
   </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>{% if page.seo_title %}{{ page.seo_title }}{% elsif page.url == '/' %}{{ site.title }}{% else %}{{ page.title }} – {{ site.title }}{% endif %}</title>
     {% include seo.html %}
-    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+    {% include head-css.html %}
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Lato:ital,wght@0,300;0,400;0,700;1,400&family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
     <script src="https://unpkg.com/tone"></script>

--- a/_layouts/dispositivo.html
+++ b/_layouts/dispositivo.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }} – {{ site.title }}{% endif %}</title>
     {% include seo.html %}
-    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+    {% include head-css.html %}
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Lato:ital,wght@0,300;0,400;0,700;1,400&family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;1,400&display=swap" rel="stylesheet">
     {% include analytics.html %}
   </head>

--- a/_layouts/imagen.html
+++ b/_layouts/imagen.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }} · {{ site.title }}{% endif %}</title>
   {% include seo.html %}
-  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+  {% include head-css.html %}
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Lato:ital,wght@0,300;0,400;0,700;1,400&display=swap" rel="stylesheet">
   {% include analytics.html %}
 </head>

--- a/_layouts/melange-report.html
+++ b/_layouts/melange-report.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }} – {{ site.title }}{% endif %}</title>
     {% include seo.html %}
-    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+    {% include head-css.html %}
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Lato:ital,wght@0,300;0,400;0,700;1,400&display=swap" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/p5@1.9.0/lib/p5.min.js"></script>
     <script src="https://unpkg.com/tone"></script>

--- a/_layouts/poems.html
+++ b/_layouts/poems.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>{% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }} · {{ site.title }}{% endif %}</title>
   {% include seo.html %}
-  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+  {% include head-css.html %}
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Lato:ital,wght@0,300;0,400;0,700;1,400&display=swap" rel="stylesheet">
   {% include analytics.html %}
 </head>


### PR DESCRIPTION
## ∴ Hermes · tech

El CSS tarda hasta 4 horas en actualizarse después de un deploy porque Fastly (el CDN de GitHub Pages) lo cachea con `max-age=14400`. Cloudflare está delante pero con `cf-cache-status: DYNAMIC` — pasa al origen. El problema vive en Fastly.

### Solución

Cache-busting por URL: cada deploy genera un `?v=<timestamp>` único en el link al CSS, así el navegador y Fastly ven una URL distinta, ignoran el cache viejo, y van a buscar el nuevo.

### Cambios

- **`_includes/head-css.html`** (nuevo). Centraliza el `<link rel="stylesheet">` con el cache-buster:

  ```liquid
  {%- assign css_ts = site.time | date: '%s%N' -%}
  <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: css_ts | relative_url }}">
  ```

- **6 layouts** (`default.html`, `codigo.html`, `dispositivo.html`, `imagen.html`, `melange-report.html`, `poems.html`) ahora `{% include head-css.html %}` en vez de inlinear el `<link>`.

### Detalle Liquid que costó 3 iteraciones

`'/path?v=' | append: site.time | date: '%s%N' | relative_url` **no funciona.** El `date: '%s%N'` aplicado a un string concatenado parsea y devuelve un epoch (número), no lo que esperás. La salida era `href="/1781554171000000000"`, un número puro.

**El fix:** hacer `date` ANTES de `append`:

```liquid
{%- assign css_ts = site.time | date: '%s%N' -%}  ← date sobre Date, devuelve número
{{ '/path?v=' | append: css_ts | relative_url }}   ← append concatena number-to-string
```

Tres intentos hasta llegar a esto. Documentado aquí para que opencode (o quien venga) no repita el ciclo.

### Verificación local

Build OK, output OK: `href="/assets/css/style.css?v=1781554199509551000"` en todos los HTMLs. Mismo path en subpaths (`/poemas/`, `/poemas/la-savia/`, etc.) — `relative_url` resuelve bien.

### Lo que **no** toqué

- **El cache de Cloudflare no se cachea** (`cf-cache-status: DYNAMIC`). Passthrough, no requiere acción.
- **El cache del browser** (más allá de Fastly) — resuelto por el mismo cache-buster: el navegador ve una URL distinta, no usa el cache viejo.
- **HTML del sitio** — `cache-control: max-age=600` (10 min). Suficientemente rápido, no necesita cache-bust.
- **El bug de `_site/` con tres `<head>` anidados** que vi mientras testeaba: era un `_site/` viejo, se regeneró limpio.

### Lo que **no** sé

- Si Fastly decide cachear también los HTMLs con `?v=` en el link interno — improbable, pero posible. Si pasa, Fastly sirve HTML viejo con link a CSS nuevo, lo que sigue siendo correcto.
- Si Cloudflare empieza a cachear en el futuro (cambio de config), el cache-bust sigue funcionando porque el query string invalida la key.

### Firma

```
∴ Hermes
∴ Cache es memoria. Memoria necesita motivos para olvidar.
```
