### PR TITLE
fix(generator): populate effect selector with 15 options

### DIFF
--- a/assets/js/umbral-vision/app.js
+++ b/assets/js/umbral-vision/app.js
@@ -46,11 +46,39 @@ function changeEffectHandler(effectName) {
 }
 
 /**
+ * Nombres legibles para cada efecto
+ */
+const EFFECT_LABELS = {
+  tunnel: 'Túnel',
+  spiral: 'Espiral',
+  mandala: 'Mándala',
+  particles: 'Partículas',
+  waves: 'Olas',
+  fractal: 'Fractal',
+  matrix: 'Matrix',
+  glitch: 'Glitch',
+  melt: 'Melt',
+  fractalGlitch: 'Fractal Glitch',
+  waveGlitch: 'Wave Glitch',
+  sacredGeometry: 'Geometría Sagrada',
+  biomech: 'Biomech',
+  dune: 'Duna',
+  yinYang: 'Yin Yang'
+};
+
+/**
  * Configurar selector de efectos
  */
 function setupEffectSelector() {
   const effectSelect = document.getElementById('effectSelect');
   if (!effectSelect) return;
+
+  effectNames.forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = EFFECT_LABELS[name] || name;
+    effectSelect.appendChild(opt);
+  });
 
   effectSelect.addEventListener('change', (e) => {
     changeEffectHandler(e.target.value);


### PR DESCRIPTION

## Bug

El `<select id="effectSelect">` estaba vacío. `setupEffectSelector()` solo añadía un listener de `change`, pero nunca creaba los `<option>`. Resultado: solo se mostraba el efecto default (`tunnel`) sin forma de elegir otro.

## Fix

- `EFFECT_LABELS`: mapa de nombres legibles en español
- `setupEffectSelector()`: itera `effectNames` y crea un `<option>` por cada efecto

## Opciones

Túnel · Espiral · Mándala · Partículas · Olas · Fractal · Matrix · Glitch · Melt · Fractal Glitch · Wave Glitch · Geometría Sagrada · Biomech · Duna · Yin Yang
